### PR TITLE
Fixes module function and manifest function comparison tests

### DIFF
--- a/PSQualityCheck.Functions.psm1
+++ b/PSQualityCheck.Functions.psm1
@@ -401,8 +401,7 @@ function Get-FunctionCount {
 
     try {
         if (Test-Path -Path $ManifestFile) {
-            $ExportedCommands = @((Test-ModuleManifest -Path $ManifestFile).ExportedCommands)
-            $ExportedCommandsCount = $ExportedCommands.Count
+            $ExportedCommandsCount = (Test-ModuleManifest -Path $ManifestFile).ExportedCommands.Count
         }
         else {
             throw "Manifest file doesn't exist"
@@ -467,7 +466,7 @@ function Get-FunctionCount {
 
     }
 
-    return ($ExportedCommandsCount, $CommandFoundInModuleCount, $CommandInModule, $CommandFoundInManifestCount)
+    return ($ExportedCommandsCount, $CommandFoundInModuleCount, $CommandInModuleCount, $CommandFoundInManifestCount)
 
 }
 


### PR DESCRIPTION
- Fixed a bug where the count of modules from the manifest was not being passed back correctly.
- Fixed a bug where the count of functions exported from the manifest was not being calculated correctly.